### PR TITLE
Relax compat restrictions on DataStructures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StreamSampling"
 uuid = "ff63dad9-3335-55d8-95ec-f8139d39e468"
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -15,7 +15,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 julia = "1.8"
 Accessors = "0.1"
-DataStructures = "0.18"
+DataStructures = "0.18, 0.19"
 Distributions = "0.25"
 HybridStructs = "0.2"
 OnlineStatsBase = "1"


### PR DESCRIPTION
StreamSampling is a bit overrestrictive on DataStructures compatibility and this causes conflicts when using `Agents.jl` (which depends on StreamSampling) and other packages. Tests pass on my end.